### PR TITLE
apq8084: Define qcal530_prop as property_type

### DIFF
--- a/apq8084/file.te
+++ b/apq8084/file.te
@@ -28,4 +28,3 @@
 # qca data file for apq8084
 type qca1530_data_file, file_type, data_file_type;
 type sysfs_qca1530, file_type;
-type qca1530_prop, file_type;

--- a/apq8084/qca1530.te
+++ b/apq8084/qca1530.te
@@ -26,6 +26,7 @@
 
 type qca1530, domain, domain_deprecated;
 type qca1530_exec, exec_type, file_type;
+type qca1530_prop, property_type;
 net_domain(qca1530)
 init_daemon_domain(qca1530)
 


### PR DESCRIPTION
A typo in apq8084 defines qcal530_prop as file_type.  This collides
with

  neverallow * ~property_type:property_service set;

in system/sepolicy/domain.te.

Change-Id: I2d16b84509d4c0f8d61c822795cd0da7e479c5cd
Signed-off-by: Corinna Vinschen <xda@vinschen.de>